### PR TITLE
A guidescanpy decode command

### DIFF
--- a/src/guidescanpy/__main__.py
+++ b/src/guidescanpy/__main__.py
@@ -1,9 +1,9 @@
 import sys
 import guidescanpy
 from guidescanpy.flask import create_app
+from guidescanpy.commands.decode import main as decode  # noqa: F401
 
-
-commands = ("web",)
+commands = ("web", "decode")
 
 
 def print_usage():

--- a/src/guidescanpy/commands/decode.py
+++ b/src/guidescanpy/commands/decode.py
@@ -1,0 +1,65 @@
+import argparse
+from guidescanpy.flask.core.genome import GenomeStructure
+
+
+def get_parser(parser):
+    parser.add_argument(
+        "grna_database", help="SAM/BAM file containing Guidescan2 processed gRNAs."
+    )
+    parser.add_argument(
+        "fasta_file", help="FASTA file for resolving off-target sequences."
+    )
+    parser.add_argument("chr2acc_file", help="chr2acc file for chromosome resolution")
+    parser.add_argument(
+        "--region", action="append", type=str, help="One or more region strings"
+    )
+
+    parser.add_argument(
+        "--mode",
+        help="Succinct or complete off-target information.",
+        choices=["succinct", "complete"],
+        default="succinct",
+    )
+
+    return parser
+
+
+def main(args):
+    parser = argparse.ArgumentParser(description=__doc__)
+    args = get_parser(parser).parse_args(args)
+
+    if not bool(args.region):
+        region_string = None
+    else:
+        region_string = "\r\n".join(args.region)
+
+    genome = GenomeStructure(
+        bam_filepath=args.grna_database, chr2acc_filepath=args.chr2acc_file
+    )
+    regions = genome.parse_regions(region_string=region_string)
+
+    if args.mode == "succinct":
+        print(
+            "id,sequence,chromosome,position,sense,distance_0_matches,distance_1_matches,distance_2_matches,distance_3_matches,specificity"
+        )
+
+        for region in regions:
+            results = genome.query(
+                region, bam_filepath=args.grna_database, reorder=False
+            )
+            for i, result in enumerate(results):
+                cols = [
+                    result["id"],
+                    result["sequence"],  # Forward sequence regardless of strand
+                    result["reference-name"],
+                    result["start"],  # 1-indexed start position
+                    result["direction"],
+                    result["offtargets-by-distance"][0],
+                    result["offtargets-by-distance"][1],
+                    result["offtargets-by-distance"][2],
+                    result["offtargets-by-distance"][3],
+                    result["specificity"],
+                ]
+                print(",".join(str(col) for col in cols))
+    else:
+        raise RuntimeError("Not implemented yet")

--- a/src/guidescanpy/flask/core/decode_database.py
+++ b/src/guidescanpy/flask/core/decode_database.py
@@ -80,14 +80,10 @@ def calc_cfd_e(sg, wt, pam, mm_scores, pam_scores):
     wt_list = list(wt)
     sg_list = list(sg)
     for i, wl in enumerate(wt_list):
-        if sg_list[i] == wl:
-            score *= 1
-        else:
-            try:
-                key = "r" + sg_list[i] + ":d" + revcom(wl) + "," + str(i + 1)
+        if sg_list[i] != wl:
+            key = "r" + sg_list[i] + ":d" + revcom(wl) + "," + str(i + 1)
+            if key in mm_scores:
                 score *= mm_scores[key]
-            except KeyError:
-                continue
     score *= pam_scores[pam]
     return score
 
@@ -286,9 +282,9 @@ if __name__ == "__main__":
 
     if args.mode == "succinct":
         print(SUCCINCT_HEADER)
-        for sam_record in sam_db:
+        for i, sam_record in enumerate(sam_db):
             output_succinct(sam_record, list(decode_ot(sam_record)))
     elif args.mode == "complete":
         print(COMPLETE_HEADER)
-        for sam_record in sam_db:
+        for i, sam_record in enumerate(sam_db):
             output_complete(decode_ot(sam_record))

--- a/src/guidescanpy/flask/db.py
+++ b/src/guidescanpy/flask/db.py
@@ -162,6 +162,8 @@ def get_chromosome_interval_trees():
     query = sql.SQL(
         "SELECT chromosome, start_pos, end_pos, exon_number, product FROM exons"
     )
+    if conn is None:
+        return {}
     cur = conn.cursor(cursor_factory=DictCursor)
     cur.execute(query)
     result = cur.fetchall()


### PR DESCRIPTION
A `guidescanpy decode` command that takes in `grna_database, fasta_file, chr2acc_file` (and zero or more optional `--region` flags) to decode a Guidescan database (`.bam` file).

Only `--mode succinct` is supported for now. 