### PR TITLE
pulling latest DDL from live db

### DIFF
--- a/scripts/init_db.sql
+++ b/scripts/init_db.sql
@@ -23,10 +23,10 @@ create table if not exists libraries
 
 create table if not exists chromosomes
 (
-    accession varchar(1023) not null
-        primary key,
+    accession varchar(1023) not null,
     name      varchar(1023) not null,
-    organism  varchar(1023) not null
+    organism  varchar(1023) not null,
+    primary key (accession, name, organism)
 );
 
 


### PR DESCRIPTION
Different "versions" of the same organism (e.g. `hg38`/`t2t`) can have chromosomes with same names/accession numbers. This change pulls the DDL from the Postgres server that is currently live, where Henri has already made this minor change.

This is not an ideal change since the absolutely "correct" thing to do here would be to have a unique constraint on (organism, name) and another unique constraint on (organism, accession). The current change leaves open the possibility of having two identical accession numbers for an organism with different "names", which doesn't make sense. However, this change is already deployed and "good enough" for practical purposes, so let's not change it.