### PR TITLE
Simplified decision on add-tag output file format.

### DIFF
--- a/src/guidescanpy/commands/add_tag.py
+++ b/src/guidescanpy/commands/add_tag.py
@@ -1,6 +1,5 @@
 import argparse
 import pysam
-import os.path
 
 supported_tags = ["ce"]
 supported_formats = ["sam", "bam"]
@@ -23,15 +22,13 @@ def get_parser(parser):
 
 
 def add_tag(tag_name, input_file, output_file):
-    output_format = get_format(output_file)
-
-    if output_format == "bam":
+    if output_file.endswith(".bam") or output_file.endswith(".bam.sorted"):
         writing_mode = "wb"
-    elif output_format == "unknown":
+    elif output_file.endswith(".sam"):
+        writing_mode = "w"
+    else:
         print("Unknown output format. Using default format 'bam'.")
         writing_mode = "wb"
-    else:
-        writing_mode = "w"
 
     with pysam.AlignmentFile(input_file) as input_file, pysam.AlignmentFile(
         output_file, writing_mode, header=input_file.header
@@ -57,16 +54,6 @@ def get_tag_value(tag_name, read):
                 f"Unsupported tag. The tag_name should be in {supported_tags}"
             )
     return tag_value
-
-
-def get_format(file):
-    while True:
-        file, extension = os.path.splitext(file)
-        if len(extension) == 0:
-            break
-        if extension[1:] in supported_formats:
-            return extension[1:]
-    return "unknown"
 
 
 def main(args):


### PR DESCRIPTION
Used `.endswith()` methods on output file name in `add-tag` command. Deleted the `get_format` function. 

The logic now is like: if the output filename ends with `.bam` or `.bam.sorted`, then generate a `bam` file; elif it ends with `.sam`, then generate a `sam` file; otherwise print an "unknown" prompt and generate a `bam` file by default.