### PR TITLE
Matplotlib Backend with MacOS

### DIFF
--- a/docker/snakemake/rs2/analysis/util.py
+++ b/docker/snakemake/rs2/analysis/util.py
@@ -1,4 +1,6 @@
 import pandas
+import matplotlib
+matplotlib.use('TkAgg')  # Set TkAgg as Matplotlib backend for macOS users
 import matplotlib.pylab as plt
 import scipy.stats
 import scipy as sp


### PR DESCRIPTION
Previously, when running `rs2/main.py` on MacOS, `RuntimeError: Python is not installed as a framework. The Mac OS X backend will not be able to function correctly if Python is not installed as a framework` will occur. 

`Matplotlib` supports multiple backends, and the default one for MacOS is `MacOSX`, which doesn't interact well with certain `Python` installation (I'm not quite sure about the reason behind this). Setting the backend to `TkAgg` manually will solve this problem.