### PR TITLE
cpf1 sequence correction

### DIFF
--- a/docker/snakemake/Snakefile
+++ b/docker/snakemake/Snakefile
@@ -118,14 +118,15 @@ rule guidescan_enumerate:
         "env.yaml"
     params:
         index_file = f"{OUTPUT_DIR}/indices/{{organism}}.index",
-        alt_pam = lambda wildcards: "--alt-pam NAG" if wildcards.enzyme == "cas9" else ""
+        alt_pam = lambda wildcards: "--alt-pam NAG" if wildcards.enzyme == "cas9" else "",
+        match_start= lambda wildcards: "--start" if wildcards.enzyme == "cpf1" else ""
     input:
         kmers_file = f"{OUTPUT_DIR}/kmers/{{enzyme}}/{{organism}}.csv",
         index_gs = f"{OUTPUT_DIR}/indices/{{organism}}.index.gs"
     output:
         f"{OUTPUT_DIR}/databases/{{enzyme}}/{{organism}}.sam"
     shell: """
-        guidescan enumerate {params.index_file} --kmers-file {input.kmers_file} --output {output} --format sam {params.alt_pam}
+        guidescan enumerate {params.index_file} --kmers-file {input.kmers_file} --output {output} --format sam {params.alt_pam} {params.match_start}
         """
 
 

--- a/src/guidescanpy/flask/core/genome.py
+++ b/src/guidescanpy/flask/core/genome.py
@@ -234,12 +234,17 @@ class GenomeStructure:
                 off_target_tuples = hex_to_offtarget_info(
                     offtarget_hex, delim=self.off_target_delim
                 )
+                total_off_target = len(
+                    off_target_tuples
+                )  # This will be used to get the number of 0-off-target
 
                 # Remove off-target entries with distance = 0 (should be just the first, but we go through all anyway)
                 off_target_tuples = tuple(t for t in off_target_tuples if t[0] != 0)
 
                 off_targets = []
                 off_targets_by_distance = defaultdict(int)
+                off_targets_by_distance[0] = total_off_target - len(off_target_tuples)
+
                 for dist, pos in off_target_tuples:
                     dist = int(dist)  # TODO: Do we need this?
                     (

--- a/src/guidescanpy/flask/core/genome.py
+++ b/src/guidescanpy/flask/core/genome.py
@@ -234,7 +234,7 @@ class GenomeStructure:
                 off_target_tuples = hex_to_offtarget_info(
                     offtarget_hex, delim=self.off_target_delim
                 )
-                total_off_target = len(
+                total_off_target_tuples = len(
                     off_target_tuples
                 )  # This will be used to get the number of 0-off-target
 
@@ -243,7 +243,9 @@ class GenomeStructure:
 
                 off_targets = []
                 off_targets_by_distance = defaultdict(int)
-                off_targets_by_distance[0] = total_off_target - len(off_target_tuples)
+                off_targets_by_distance[0] = total_off_target_tuples - len(
+                    off_target_tuples
+                )
 
                 for dist, pos in off_target_tuples:
                     dist = int(dist)  # TODO: Do we need this?


### PR DESCRIPTION
`guidescan enumerate` has a `--start` flag, too. We didn't add this to the snakemake rule before, so the `bam` files appended the pam to the end of the sequences as default. 

For example, the correct sequence of a target should be `TTTNGGCCTAATACTAAGCCTAAG`, but the `bam` files generated from snakemake write it as `GGCCTAATACTAAGCCTAAGTTTN`. 

This PR made a correction for this.