### PR TITLE
guidescanpy filter_tag command; minor other tweaks

### DIFF
--- a/docker/snakemake/Snakefile
+++ b/docker/snakemake/Snakefile
@@ -129,7 +129,7 @@ rule guidescan_enumerate:
         """
 
 
-rule sam_to_bam:
+rule guidescan_filter_tag:
     conda:
         "env.yaml"
     input:
@@ -137,11 +137,12 @@ rule sam_to_bam:
     output:
         f"{OUTPUT_DIR}/databases/{{enzyme}}/{{organism}}.bam"
     shell: """
-        python -c "import pysam; pysam.sort('-o', '{output}', '{input}'); pysam.index('{output}')"
+        guidescanpy filter-tag --input {input} --output {output}
+        python -c "import pysam; pysam.sort('-o', '{output}', '{output}'); pysam.index('{output}')"
         """
 
 
-rule add_ce:
+rule guidescan_add_ce:
     conda:
         "rs2/env.yaml"
     input:
@@ -151,5 +152,6 @@ rule add_ce:
         f"{OUTPUT_DIR}/databases/{{enzyme}}/{{organism}}.bam.sorted"
     shell: """
         python rs2/main.py {input.bam_file} {input.fna_file} {output}
+        python -c "import pysam; pysam.sort('-o', '{output}', '{output}'); pysam.index('{output}')"
         """
 # -----------------------------------------------------------------------------

--- a/docker/snakemake/env.yaml
+++ b/docker/snakemake/env.yaml
@@ -3,7 +3,7 @@ channels:
   - bioconda
 dependencies:
   - python ==3.10.11
-  - guidescan
+  - guidescan=2.1.5
   - pip
   - pip:
     - guidescanpy[web] @ git+https://github.com/pritykinlab/guidescanpy.git

--- a/src/guidescanpy/__main__.py
+++ b/src/guidescanpy/__main__.py
@@ -5,9 +5,19 @@ from guidescanpy.commands.decode import main as decode  # noqa: F401
 from guidescanpy.commands.generate_kmers import main as generate_kmers  # noqa: F401
 from guidescanpy.commands.add_organism import main as add_organism  # noqa: F401
 from guidescanpy.commands.init_db import main as init_db  # noqa: F401
+from guidescanpy.commands.filter_tag import main as filter_tag  # noqa: F401
 from guidescanpy.commands.add_tag import main as add_tag  # noqa: F401
 
-commands = ("web", "decode", "generate-kmers", "init-db", "add-organism", "add-tag")
+
+commands = (
+    "web",
+    "decode",
+    "generate-kmers",
+    "init-db",
+    "add-organism",
+    "filter-tag",
+    "add-tag",
+)
 
 
 def print_usage():

--- a/src/guidescanpy/commands/add_tag.py
+++ b/src/guidescanpy/commands/add_tag.py
@@ -1,8 +1,7 @@
 import argparse
 import pysam
 
-supported_tags = ["ce"]
-supported_formats = ["sam", "bam"]
+supported_tags = ("ce",)
 
 
 def get_parser(parser):
@@ -13,10 +12,14 @@ def get_parser(parser):
         help="List of tags to add.",
     )
     parser.add_argument(
-        "--input", "-i", type=str, help="Path to the input sam/bam file."
+        "--input", "-i", type=str, required=True, help="Path to the input sam/bam file."
     )
     parser.add_argument(
-        "--output", "-o", type=str, help="Path to the output sam/bam file."
+        "--output",
+        "-o",
+        type=str,
+        required=True,
+        help="Path to the output sam/bam file.",
     )
     return parser
 

--- a/src/guidescanpy/commands/filter_tag.py
+++ b/src/guidescanpy/commands/filter_tag.py
@@ -1,0 +1,66 @@
+import argparse
+import math
+import pysam
+
+
+def get_parser(parser):
+    parser.add_argument(
+        "--input", "-i", type=str, required=True, help="Path to the input sam/bam file."
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=str,
+        required=True,
+        help="Path to the output sam/bam file.",
+    )
+    parser.add_argument(
+        "--k0",
+        type=int,
+        default=1,
+        help="Max number of off-targets at distance 0 (default=%(default)s)",
+    )
+    parser.add_argument(
+        "--k1",
+        type=int,
+        default=0,
+        help="Max number of off-targets at distance 1 (default=%(default)s)",
+    )
+    parser.add_argument(
+        "--k2",
+        type=int,
+        default=math.inf,
+        help="Max number of off-targets at distance 2 (default=%(default)s)",
+    )
+    parser.add_argument(
+        "--k3",
+        type=int,
+        default=math.inf,
+        help="Max number of off-targets at distance 3 (default=%(default)s)",
+    )
+    return parser
+
+
+def main(args):
+    parser = argparse.ArgumentParser(
+        description="Filter a sam/bam file based on the number of offtargets at a given distance."
+    )
+    args = get_parser(parser).parse_args(args)
+
+    input_file, output_file = args.input, args.output
+
+    if output_file.endswith(".bam") or output_file.endswith(".bam.sorted"):
+        writing_mode = "wb"
+    elif output_file.endswith(".sam"):
+        writing_mode = "w"
+    else:
+        print("Unknown output format. Using default format 'bam'.")
+        writing_mode = "wb"
+
+    with pysam.AlignmentFile(input_file) as input_file, pysam.AlignmentFile(
+        output_file, writing_mode, header=input_file.header
+    ) as output_file:
+        for read in input_file:
+            for ki in ("k0", "k1", "k2", "k3"):
+                if read.has_tag(ki) and read.get_tag(ki) <= getattr(args, ki):
+                    output_file.write(read)


### PR DESCRIPTION
`guidescan filter-tag` command (with sensible defaults for k0/k1/k2/k3) that sits between `guidescan enumerate` and `guidescan_add_ce`.

`guidescan_add_ce` takes in optional region paramters (for example one invocation might be `python rs2/main.py {input.bam_file} {input.fna_file} {output} --contig NC_001133.9 --start 10000 --end 20000` instead of the default), to speed up testing.

I've removed `sam_to_bam` since I now agree with your original logic of having the rule do what it wants and add an indexing step right after it. That way we can index whatever/whenever we need to for the next step to proceed.