### PR TITLE
bug fix in filter_tag; multiprocessed add_ce step

### DIFF
--- a/src/guidescanpy/commands/filter_tag.py
+++ b/src/guidescanpy/commands/filter_tag.py
@@ -61,6 +61,9 @@ def main(args):
         output_file, writing_mode, header=input_file.header
     ) as output_file:
         for read in input_file:
-            for ki in ("k0", "k1", "k2", "k3"):
-                if read.has_tag(ki) and read.get_tag(ki) <= getattr(args, ki):
-                    output_file.write(read)
+            invalid_read = any(
+                read.has_tag(ki) and read.get_tag(ki) > getattr(args, ki)
+                for ki in ("k0", "k1", "k2", "k3")
+            )
+            if not invalid_read:
+                output_file.write(read)


### PR DESCRIPTION
Bug fix with `filter_tag` which was initially producing 4 output reads for each input bam read.

`guidescan_add_ce` is now multi-core aware and can be passed a `--workers` flag. Note that each chromosome (contig) is handled in its own process. To keep the code simple, `--contig/--start/--end` are no longer supported (which were for temporary testing anyway).