### PR TITLE
resolved TODO comments in db.py and library.py

### DIFF
--- a/src/guidescanpy/flask/blueprints/library.py
+++ b/src/guidescanpy/flask/blueprints/library.py
@@ -55,7 +55,6 @@ def library(
     frac_control: float = 0.0,
     append5: bool = False,
 ):
-    # TODO: Why is this \r\n and not just \n?
     genes = genes.splitlines()
 
     library_info = get_library_info_by_gene(organism, genes, n_guides)
@@ -64,7 +63,6 @@ def library(
     results = []
     for i, genes in enumerate(genes_by_pool_index):
         n_essential_genes = round(frac_essential * len(genes))
-        # TODO: randomize
         essential_genes = get_essential_genes(organism, n_essential_genes)
         essential_genes_library_info = get_library_info_by_gene(
             organism, essential_genes, n_guides
@@ -73,7 +71,6 @@ def library(
         n_control_guides = round(
             frac_control * len(genes)
         )  # TODO: Clojure code does this, but it doesn't seem correct
-        # TODO: randomize
         control_guides = get_control_guides(organism, n_control_guides)
 
         for gene in genes:

--- a/src/guidescanpy/flask/db.py
+++ b/src/guidescanpy/flask/db.py
@@ -95,7 +95,7 @@ def create_region_query(organism, region):
     results = conn.execute(query, {"organism": organism, "entrez_id": region})
     for row in results.mappings():
         return_value = dict(row)
-        # TODO: sqlite backend seems to return boolean as int
+
         return_value["sense"] = bool(return_value["sense"])
         return return_value
 
@@ -132,17 +132,21 @@ def get_library_info_by_gene(organism, genes, n_guides=6):
 def get_essential_genes(organism, n=1):
     conn = get_connection()
     query = text(
-        "SELECT gene_symbol FROM essential_genes WHERE organism = :organism LIMIT :n"
+        "SELECT gene_symbol FROM essential_genes WHERE organism = :organism ORDER BY RANDOM() LIMIT :n"
     )
     results = conn.execute(query, {"organism": organism, "n": n})
-    return [r[0] for r in results]  # TODO: Ugly!
+
+    return_value = []
+    for row in results.mappings():
+        return_value.append(row["gene_symbol"])
+    return return_value
 
 
 def get_control_guides(organism, n=1):
     conn = get_connection()
-    # TODO: Order by?
+
     query = text(
-        "SELECT * FROM libraries WHERE organism = :organism AND (grna_type='safe_targeting_control' OR grna_type='non_targeting_control') LIMIT :n"
+        "SELECT * FROM libraries WHERE organism = :organism AND (grna_type='safe_targeting_control' OR grna_type='non_targeting_control') ORDER BY RANDOM() LIMIT :n"
     )
     results = conn.execute(query, {"organism": organism, "n": n})
     return [dict(row) for row in results.mappings()]


### PR DESCRIPTION
Addressed TODO comments in db.py and removed TODO comments in library.py based on edits done in db.py:
- Added ORDER BY RANDOM() to get_essential_genes and get_control_guides to match the original Clojure implementation
- Cleaned up get_essential_genes 
- Removed resolved TODO comments

Note that there are two TODOs (one in db.py and library.py) that still need addressing: 
- get_library_info_by_gene line 114: unclear if ORDER BY is needed or if sorting should happen in library.py after fetching based on Clojure implementation 
- library.py line 73: unsure if control guide percentage calculation may not be correct via the TODO comment referencing the Clojure implementation
